### PR TITLE
make command print specified line of file

### DIFF
--- a/equator.py
+++ b/equator.py
@@ -1,8 +1,8 @@
 import sys
 
-linenum=int(sys.argv[1])-1
+linenum = int(sys.argv[1]) - 1
 
 with open(sys.argv[2], 'r') as file:
     for i, line in enumerate(file):
         if i == linenum:
-            print(line.rstrip('\n\r]'))
+            print(line.rstrip('\n\r'))

--- a/equator.py
+++ b/equator.py
@@ -1,5 +1,8 @@
 import sys
 
-with open(sys.argv[1], 'r') as file:
-    for line in file:
-        print(line.rstrip('\n\r'))
+linenum=int(sys.argv[1])-1
+
+with open(sys.argv[2], 'r') as file:
+    for i, line in enumerate(file):
+        if i == linenum:
+            print(line.rstrip('\n\r]'))


### PR DESCRIPTION
fixes #5

- first argument is intially a string, ``int()`` is used to turn it into an integer.
- ``linenum`` subtracts 1 from the first argument, as the line numbers in a file start at 0
- ``enumerate()`` returns a tuple, hence ``i, line``
- ``==`` is equivalent to the mathematical `=`, rather than where python often uses `=` to assign values. Here we are checking whether ``i`` and ``linenum`` are the same